### PR TITLE
feat: Add option to use ignore files like .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,19 @@ Code is processed and tokenized by `jscpd` in order to find repetitions that are
 
 Set whether the linter should look for repetitions only in the current file, or throughout the current project.
 
-### Files to ignore
+### `.ignore` files
 
 - type: `'array'` of strings
-- default: `['**/node_modules/**', '**/.git/**', '**/*.min.*']`
+- default: `['.gitignore']`
 
-Files that match any of the patterns set here will be ignored when looking for repetition. (See [`minimatch`](https://github.com/isaacs/minimatch/#minimatch) for globbing documentation.)
+Specify files like `.gitignore` or `.npmignore` to use in deciding which files linter-dryer should ignore.
+
+### Additional ignore patterns
+
+- type: `'array'` of strings
+- default: `['**/*.min.*']`
+
+Files that match any of the patterns set here will be ignored when looking for repetition. (See [`minimatch`](https://github.com/isaacs/minimatch/#minimatch) for globbing documentation.) These patterns are applied _in addition_ to rules found in any files set in the **.ignore files** option.
 
 ### Repetition severity
 

--- a/lib/cpd.js
+++ b/lib/cpd.js
@@ -2,6 +2,7 @@
 
 import { dirname, basename } from 'path'
 import jscpd from 'jscpd'
+import { fileWatcher } from './linter-dryer'
 
 /**
  * Use `jscpd` to detect “copy-paste” instances
@@ -16,7 +17,7 @@ async function detectCopyPaste (textEditor) {
   const exclude = atom.config.get('linter-dryer.exclude')
   const opts = {
     path: scope === 'project' ? atom.project.getPaths()[0] : dirname(editorPath),
-    files: scope === 'project' ? '**/*' : basename(editorPath),
+    files: scope === 'project' ? await fileWatcher.getFiles() : basename(editorPath),
     exclude,
     reporter: 'json',
     'min-lines': minLines,

--- a/lib/file-watcher.js
+++ b/lib/file-watcher.js
@@ -1,0 +1,64 @@
+'use babel'
+
+import walk from 'ignore-walk'
+
+export default (function () {
+  'use strict'
+
+  const watcher = {}
+
+  /**
+   * Start file watching if linter scope is 'project' and stop if it is 'file'
+   * @param  {String} scope The current linterScope setting: 'project' or 'file'
+   * @return {Promise<undefined>}
+   */
+  const handleLinterScope = async function functionName (scope) {
+    if (scope === 'project' && (!watcher.listener || watcher.listener.disposed)) {
+      watcher.listener = atom.project.onDidChangeFiles(walkFiles)
+      await walkFiles()
+    } else if (watcher.listener && !watcher.listener.disposed) {
+      watcher.listener.dispose()
+    }
+  }
+
+  /**
+   * Collect project file paths using `ignore-walk` & filter out `.git` paths
+   * @return {Promise<undefined>}
+   */
+  const walkFiles = async function walkFiles () {
+    const files = await walk({
+      path: atom.project.getPaths()[0],
+      ignoreFiles: atom.config.get('linter-dryer.ignoreFiles')
+    })
+    watcher.files = files.filter(path => !/\.git\//.test(path))
+  }
+
+  return {
+    /**
+     * Initialise a disposable fileWatcher instance by observing linter scope
+     * @return {Promise<undefined>}
+     */
+    start: async function functionName () {
+      if (!watcher.atomConfigListener || watcher.atomConfigListener.disposed) {
+        watcher.atomConfigListener = atom.config.observe('linter-dryer.linterScope', handleLinterScope)
+      }
+    },
+
+    /**
+     * Get the files retrieved using `ignore-walk`
+     * @return {Promise<String[]>} Array of file paths in the current project
+     */
+    getFiles: async function getFiles () {
+      return watcher.files
+    },
+
+    /**
+     * Dispose of fileWatcher’s internal listeners
+     * @return {undefined}
+     */
+    dispose: function functionName () {
+      watcher.listener.dispose()
+      watcher.atomConfigListener.dispose()
+    }
+  }
+}())

--- a/lib/linter-dryer.js
+++ b/lib/linter-dryer.js
@@ -1,8 +1,11 @@
 'use babel'
 
+import fileWatcher from './file-watcher'
+
 export default {
   config: {
     minimumLines: {
+      order: 1,
       type: 'integer',
       default: 3,
       minimum: 1,
@@ -10,6 +13,7 @@ export default {
       description: 'This sets how many lines must repeat before they are flagged as a repetition'
     },
     minimumTokens: {
+      order: 2,
       type: 'integer',
       default: 25,
       minimum: 1,
@@ -17,25 +21,38 @@ export default {
       description: 'Code is processed and tokenized in order to find repetition in similar but slightly different code. This sets how many tokens need to match to qualify as a repetition. Values that are too low may produce meaningless output.'
     },
     linterScope: {
+      order: 3,
       type: 'string',
       default: 'file',
       enum: [
-        { value: 'file', description: 'file — finds repetitions within a single file' },
-        { value: 'project', description: 'project — finds repetitions across your project' }
+        { value: 'file', description: 'file — shows repetitions within the current file' },
+        { value: 'project', description: 'project — shows repetitions across your project' }
       ],
       title: 'Scope to search for repetitions',
       description: 'This sets where the linter looks for repetitions'
     },
-    exclude: {
+    ignoreFiles: {
+      order: 4,
       type: 'array',
       items: {
         type: 'string'
       },
-      default: ['**/node_modules/**', '**/.git/**', '**/*.min.*'],
-      title: 'Files to ignore (list of glob patterns)',
-      description: 'Specify file globs to ignore when looking for repetitions across the project'
+      default: ['.gitignore'],
+      title: '.ignore files',
+      description: 'Specify files like `.gitignore` or `.npmignore` to use in deciding which files linter-dryer should ignore'
+    },
+    exclude: {
+      order: 5,
+      type: 'array',
+      items: {
+        type: 'string'
+      },
+      default: ['**/*.min.*'],
+      title: 'Additional ignore patterns',
+      description: 'Files that match any of the patterns set here will be ignored when looking for repetition. (See [`minimatch`](https://github.com/isaacs/minimatch/#minimatch) for globbing documentation.) These patterns are applied _in addition_ to rules found in any files set in the **.ignore files** option.'
     },
     severity: {
+      order: 6,
       type: 'string',
       default: 'info',
       enum: ['info', 'warning', 'error'],
@@ -46,7 +63,14 @@ export default {
 
   async activate () {
     await require('atom-package-deps').install('linter-dryer')
+    await fileWatcher.start()
   },
+
+  deactivate () {
+    fileWatcher.dispose()
+  },
+
+  fileWatcher,
 
   provideLinter () {
     return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1822,6 +1822,14 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
+    "ignore-walk": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "atom-linter": "^10.0.0",
     "atom-package-deps": "^4.6.2",
+    "ignore-walk": "^3.0.1",
     "jscpd": "^0.6.24"
   },
   "package-deps": [


### PR DESCRIPTION
This uses the [`ignore-walk`](https://github.com/npm/ignore-walk) package to traverse a project’s paths, collecting all paths that are not excluded by provided ignore files such as `.gitignore` or `.npmignore`, and passing the path list to the `files` option of `jscpd`. This is only active when the linter scope is “project” and helps with project-specific exclusions such as not comparing against builds or `node_modules` etc.